### PR TITLE
Fix Sticky Posts Show on ignore_sticky_posts="yes"

### DIFF
--- a/includes/class-page-posts.php
+++ b/includes/class-page-posts.php
@@ -150,8 +150,11 @@ class ICPagePosts {
 			$this->args['paged'] = $wp_query->query_vars['page'];
 		}
 
-		if ( ! isset( $this->args['ignore_sticky_posts'] ) ) {
-			$this->args['post__not_in'] = get_option( 'sticky_posts' );
+		if ( ! ( isset( $this->args['ignore_sticky_posts'] ) &&
+                        ( strtolower( $this->args['ignore_sticky_posts'] ) === 'no' ||
+                            strtolower( $this->args['ignore_sticky_posts'] ) === 'false') ) ){
+                    
+                    $this->args['post__not_in'] = get_option( 'sticky_posts' );
 		}
 
 		$this->args['ignore_sticky_posts'] = isset( $this->args['ignore_sticky_posts'] ) ? $this->shortcode_bool( $this->args['ignore_sticky_posts'] ) : true;


### PR DESCRIPTION
Fixes #27.

The ignore_sticky_posts attribute MUST now equal "no" (ignores case) in order to display sticky posts.
"False" (ignores case) is also accepted.

Any other value (including "yes" or "true") will cause the attribute to be ignored, and fall back to the default behavior of ignoring sticky posts.
