### PR TITLE
Add post_status option

### DIFF
--- a/admin/views/help-main.php
+++ b/admin/views/help-main.php
@@ -92,6 +92,11 @@
 						<td><?php _e( "Show sticky posts too (they're ignored by default)", 'posts-in-page' ); ?></td>
 					</tr>
 					<tr>
+						<td>Post status</td>
+						<td><code>[ic_add_posts post_status='private']</code></td>
+						<td><?php _e( "Show posts with the specified status(es); the default is to only show posts with status 'publish'.  To choose more than one status, separate them with commas.  For example: <code>post_status='private,publish'</code>.", 'posts-in-page' ); ?></td>
+					</tr>
+					<tr>
 						<td>Pagination</td>
 						<td><code>[ic_add_posts paginate='yes']</code></td>
 						<td><?php _e( 'use pagination links (off by default)', 'posts-in-page' ); ?></td>

--- a/includes/class-page-posts.php
+++ b/includes/class-page-posts.php
@@ -116,6 +116,11 @@ class ICPagePosts {
 			$this->args['tag'] = $atts['tag'];
 		}
 
+        // override default post_type argument ('publish')
+        if ( isset( $atts['post_status'] ) ) {
+            $this->args['post_status'] = $atts['post_status'];
+        }
+
 		// exclude posts with certain category by name (slug)
 		if ( isset( $atts['exclude_category'] ) ) {
 			$category = $atts['exclude_category'];


### PR DESCRIPTION
On private pages, I want to be able to list private posts.  

It turned out to be a very small change to version 1.30 of Posts-in-Page to allow this.
