### PR TITLE
Prevent fatal errors caused by setting the global query to null.

### DIFF
--- a/includes/class-page-posts.php
+++ b/includes/class-page-posts.php
@@ -72,7 +72,6 @@ class ICPagePosts {
 
 		// Commandeering wp_query for pagination quirkiness.
 		$temp     = $wp_query;
-		$wp_query = null;
 		$wp_query = apply_filters( 'posts_in_page_results', new WP_Query( $this->args ) );
 
 		$output = '';
@@ -89,8 +88,8 @@ class ICPagePosts {
 		}
 
 		// Restore wp_query.
-		$wp_query = null;
 		$wp_query = $temp;
+		unset( $temp );
 		wp_reset_query(); // phpcs:ignore WordPress.WP.DiscouragedFunctions.wp_reset_query_wp_reset_query
 		remove_filter( 'excerpt_more', array( $this, 'custom_excerpt_more' ) );
 


### PR DESCRIPTION
Other plugins may check for query vars or use query conditionals before the query is reassigned to the global. If it's null, a fatal error will be thrown.